### PR TITLE
Fix Error code for GetDisplayNameOf for the Control Panel

### DIFF
--- a/dll/win32/shell32/folders/CControlPanelFolder.cpp
+++ b/dll/win32/shell32/folders/CControlPanelFolder.cpp
@@ -488,8 +488,8 @@ HRESULT WINAPI CControlPanelFolder::GetUIObjectOf(HWND hwndOwner,
 */
 HRESULT WINAPI CControlPanelFolder::GetDisplayNameOf(PCUITEMID_CHILD pidl, DWORD dwFlags, LPSTRRET strRet)
 {
-    if (!pidl)
-        return S_FALSE;
+    if (!strRet || !pidl)
+        return E_INVALIDARG;
 
     PIDLCPanelStruct *pCPanel = _ILGetCPanelPointer(pidl);
 


### PR DESCRIPTION
S_False is a success response, but was being used as a fail condition. It just isn't right to do that.